### PR TITLE
fix: UI markup

### DIFF
--- a/global.R
+++ b/global.R
@@ -24,7 +24,9 @@ if (getOption("cache", TRUE)) {
 
 # Builds theme object to be supplied to ui
 my_theme <- bs_theme(bootswatch = "litera",
-                     base_font = font_google("Merriweather Sans", local = TRUE)) # Arimo
+                     base_font = font_google("Merriweather Sans", local = TRUE)) %>% 
+            bs_add_rules("#header h2 { text-align: center }") # Arimo
+
 
 # Let thematic know to use the font from bs_lib
 # thematic_on(font = "auto")

--- a/ui.R
+++ b/ui.R
@@ -2,7 +2,7 @@ ui <- fluidPage(
   theme = my_theme,
   div(
     id = "header",
-    titlePanel(h1("How much UK electricity comes from low-carbon sources?", align = "center")),
+    titlePanel("How much UK electricity comes from low-carbon sources?"),
     div(
       style = "display: inline-block; width: 250px;",
       span("View as heatmap", style = "font-size: large;"),


### PR DESCRIPTION
Using h1() within the titlePanel(), was outputting invalid markup:

```
<title>
  <h1 align="center">How much UK electricity comes from low-carbon sources?</h1>
</title>
```

and

```
<h2>
  <h1 align="center">How much UK electricity comes from low-carbon sources?</h1>
</h2>
```